### PR TITLE
Release to bintray

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger-app/pom.xml
+++ b/debugger-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger-app/pom.xml
+++ b/debugger-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger-app/pom.xml
+++ b/debugger-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger-app/pom.xml
+++ b/debugger-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger-app/pom.xml
+++ b/debugger-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -99,17 +99,6 @@
         <filtering>false</filtering>
       </resource>
     </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>src/test/resources/org/allenai/pdfbox/examples/signature/*</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -55,15 +55,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-            <excludes>
-                <exclude>src/main/resources/org/apache/fontbox/cmap/*</exclude>
-            </excludes>
-        </configuration>
-    </plugin>
     </plugins>
   </build>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -124,25 +124,6 @@
   
     <profiles>
         <profile>
-            <id>pedantic</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.rat</groupId>
-                        <artifactId>apache-rat-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
           <id>release</id>
           <build>
             <plugins>
@@ -230,16 +211,6 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.rat</groupId>
-                    <artifactId>apache-rat-plugin</artifactId>
-                    <version>0.11</version>
-                    <configuration>
-                        <excludes>
-                            <exclude>release.properties</exclude>
-                        </excludes>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -356,4 +356,12 @@
     <url>https://github.com/allenai/pdfbox</url>
     <tag>HEAD</tag>
   </scm>
+
+    <distributionManagement>
+      <repository>
+        <id>bintray-allenai-maven</id>
+        <url>https://api.bintray.com/maven/allenai/maven/${project.groupId}:${project.artifactId}</url>
+      </repository>
+    </distributionManagement>
+
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -190,13 +190,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
-				   <execution>
-				      <id>attach-sources</id>
-				      <goals>
-				        <goal>jar</goal>
-				      </goals>
-				   </execution>
-				</executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                   </execution>
+                </executions>
             </plugin>
 	        <plugin>
 	            <groupId>org.codehaus.mojo</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -43,6 +43,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -354,6 +354,6 @@
     <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
     <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>pdfbox-reactor-2.0.0-AI2</tag>
+    <tag>HEAD</tag>
   </scm>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -354,7 +354,7 @@
     <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
     <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>pdfbox-reactor-2.0.0-AI2</tag>
+    <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -354,7 +354,7 @@
     <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
     <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>pdfbox-reactor-2.0.0-AI2</tag>
+    <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,11 +40,6 @@
         <url>http://pdfbox.apache.org</url>
     </organization>
   
-    <issueManagement>
-        <system>jira</system>
-        <url>https://issues.apache.org/jira/browse/PDFBOX</url>
-    </issueManagement>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -354,7 +354,7 @@
     <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
     <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>HEAD</tag>
+    <tag>pdfbox-reactor-2.0.0-AI2</tag>
   </scm>
 
     <distributionManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -354,7 +354,7 @@
     <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
     <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>HEAD</tag>
+    <tag>pdfbox-reactor-2.0.0-AI2</tag>
   </scm>
 
     <distributionManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,6 +119,11 @@
             <name>JBIG2 ImageIO-Plugin repository at googlecode.com</name>
             <url>https://jbig2-imageio.googlecode.com/svn/maven-repository/</url>
         </repository>
+        <repository>
+            <id>bintray-allenai-maven</id>
+            <name>allenai-maven</name>
+            <url>https://api.bintray.com/maven/allenai/maven/pdfbox-parent/;publish=1</url>
+        </repository>
     </repositories>
   
     <profiles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -159,7 +159,7 @@
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <goals>deploy</goals>
-                    <arguments>-Papache-release</arguments>
+                    <arguments>-Prelease</arguments>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -372,8 +372,9 @@
     </developers>
 
   <scm>
-    <connection>scm:svn:http://svn.apache.org/repos/asf/maven/pom/tags/2.0.0-RC2/pdfbox-parent</connection>
-    <developerConnection>scm:svn:https://svn.apache.org/repos/asf/maven/pom/tags/2.0.0-RC2/pdfbox-parent</developerConnection>
-    <url>http://svn.apache.org/viewvc/maven/pom/tags/2.0.0-RC2/pdfbox-parent</url>
+    <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
+    <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
+    <url>https://github.com/allenai/pdfbox</url>
+    <tag>HEAD</tag>
   </scm>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.1-RC2-SNAPSHOT</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.1-RC2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -173,17 +173,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <links>
-                        <link>http://download.oracle.com/javase/1.6.0/docs/api/</link>
-                    </links>
-                    <encoding>UTF-8</encoding>
-                    <notimestamp>true</notimestamp>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -354,6 +354,6 @@
     <connection>scm:git:https://github.com/allenai/pdfbox.git</connection>
     <developerConnection>scm:git:git@github.com:allenai/pdfbox.git</developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>HEAD</tag>
+    <tag>pdfbox-reactor-2.0.0-AI2</tag>
   </scm>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,6 +141,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+          <id>release</id>
+          <build>
+            <plugins>
+              <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>attach-sources</id>
+                    <goals>
+                      <goal>jar</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
+        </profile>
     </profiles>
 
     <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -159,7 +159,7 @@
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <goals>deploy</goals>
-                    <arguments>-Papache-release,pedantic</arguments>
+                    <arguments>-Papache-release</arguments>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -155,5 +155,12 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+      <repository>
+        <id>bintray-allenai-maven</id>
+        <url>https://api.bintray.com/maven/allenai/maven/org.allenai.pdfbox:pdfbox</url>
+      </repository>
+    </distributionManagement>
+
 </project>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -131,27 +131,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>src/main/resources/org/allenai/pdfbox/resources/afm/*</exclude>
-                        <exclude>src/main/resources/org/allenai/pdfbox/resources/icc/*</exclude>
-                        <exclude>src/main/resources/org/allenai/pdfbox/resources/glyphlist/glyphlist.txt</exclude>
-                        <exclude>src/main/resources/org/allenai/pdfbox/resources/glyphlist/zapfdingbats.txt</exclude>
-                        <exclude>src/main/resources/org/allenai/pdfbox/resources/text/BidiMirroring.txt</exclude>
-                        <exclude>src/main/resources/META-INF/services/*</exclude>
-                        <exclude>src/test/resources/input/rendering/*.ai</exclude>
-                        <exclude>src/test/resources/input/*.txt</exclude>
-                        <exclude>src/test/resources/output/*</exclude>
-                        <exclude>release.properties</exclude>
-                        <exclude>src/test/resources/org/allenai/pdfbox/encryption/*.der</exclude>
-                        <exclude>src/test/resources/org/allenai/pdfbox/encryption/*.pfx</exclude>
-                        <exclude>src/test/resources/org/allenai/pdfbox/filter/*.bin</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.allenai.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.0-AI2</version>
+        <version>2.0.0-AI2-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -36,10 +36,6 @@
     </description>
     <inceptionYear>2002</inceptionYear>
     
-    <properties>
-    	<git.scmJavadocUrl>git:https://git-wip-us.apache.org/repos/asf/pdfbox-docs//content/docs/${project.version}/javadocs</git.scmJavadocUrl>
-    </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.allenai.pdfbox</groupId>
@@ -154,22 +150,6 @@
                         <exclude>src/test/resources/org/allenai/pdfbox/encryption/*.pfx</exclude>
                         <exclude>src/test/resources/org/allenai/pdfbox/filter/*.bin</exclude>
                     </excludes>
-                </configuration>
-            </plugin>
-            <!-- 
-            	Publish Javadoc to Apache CMS
-            	After completion log in to https://cms.apache.org/pdfbox/publish 
-            	and click on the Submit button to commit to production.
-             -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-scm-publish-plugin</artifactId>
-                <configuration>
-                    <content>${project.reporting.outputDirectory}/apidocs</content>
-                    <pubScmUrl>scm:${git.scmJavadocUrl}</pubScmUrl>
-                    <tryUpdate>true</tryUpdate>
-                    <checkoutDirectory>${svn.scmJavadocCheckoutDirectory}</checkoutDirectory>
-                    <serverId>pdfbox-site</serverId>
                 </configuration>
             </plugin>
         </plugins>

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.allenai.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.0-RC2</version>
+        <version>2.0.1-RC2-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.allenai.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.0-AI2-SNAPSHOT</version>
+        <version>2.0.0-AI2</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.allenai.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.0-AI3-SNAPSHOT</version>
+        <version>2.0.0-AI2</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.allenai.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.1-RC2-SNAPSHOT</version>
+        <version>2.0.0-AI2-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.allenai.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.0-AI2</version>
+        <version>2.0.0-AI3-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
       scm:git:https://github.com/allenai/pdfbox.git
     </developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>HEAD</tag>
+    <tag>pdfbox-reactor-2.0.0-AI2</tag>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
       scm:git:https://github.com/allenai/pdfbox.git
     </developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>pdfbox-reactor-2.0.0-AI2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
 
   <scm>
     <connection>
-      scm:svn:http://svn.apache.org/repos/asf/pdfbox/tags/2.0.0-RC2
+      scm:git:https://github.com/allenai/pdfbox.git
     </connection>
     <developerConnection>
-      scm:svn:https://svn.apache.org/repos/asf/pdfbox/tags/2.0.0-RC2
+      scm:git:https://github.com/allenai/pdfbox.git
     </developerConnection>
-    <url>http://svn.apache.org/viewvc/pdfbox/tags/2.0.0-RC2</url>
+    <url>https://github.com/allenai/pdfbox</url>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.1-RC2-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.1-RC2-SNAPSHOT</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,43 +128,6 @@
                       </fileset>
                     </checksum>
                     <checksum file="${basedir}/target/${project.version}/pdfbox-${project.version}-src.zip" algorithm="SHA1" property="checksum" />
-                    <echo file="${basedir}/target/vote.txt">
-From: ${username}@apache.org
-To: dev@pdfbox.apache.org
-Subject: [VOTE] Release Apache PDFBox ${project.version}
-
-A candidate for the PDFBox ${project.version} release is available at:
-
-    https://dist.apache.org/repos/dist/dev/pdfbox/${project.version}/
-
-The release candidate is a zip archive of the sources in:
-
-    http://svn.apache.org/repos/asf/pdfbox/tags/${project.version}/
-
-The SHA1 checksum of the archive is ${checksum}.
-
-Please vote on releasing this package as Apache PDFBox ${project.version}.
-The vote is open for the next 72 hours and passes if a majority of at
-least three +1 PDFBox PMC votes are cast.
-
-    [ ] +1 Release this package as Apache PDFBox ${project.version}
-    [ ] -1 Do not release this package because...${line.separator}
-                    </echo>
-                    <echo />
-                    <echo>
-The release candidate has been prepared in:
-
-    ${basedir}/target/${project.version}
-
-Please deploy it to people.apache.org like this:
-
-    scp -r ${basedir}/target/${project.version} people.apache.org:public_html/pdfbox/
-
-A release vote template has been generated for you:
-
-    file://${basedir}/target/vote.txt
-                    </echo>
-                    <echo />
                   </tasks>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
@@ -40,6 +40,7 @@
       scm:git:https://github.com/allenai/pdfbox.git
     </developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
+    <tag>pdfbox-reactor-2.0.0-AI2</tag>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,6 @@
       scm:git:https://github.com/allenai/pdfbox.git
     </developerConnection>
     <url>https://github.com/allenai/pdfbox</url>
-    <tag>pdfbox-reactor-2.0.0-AI2</tag>
   </scm>
 
   <modules>

--- a/preflight-app/pom.xml
+++ b/preflight-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight-app/pom.xml
+++ b/preflight-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight-app/pom.xml
+++ b/preflight-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight-app/pom.xml
+++ b/preflight-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight-app/pom.xml
+++ b/preflight-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
         

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
         

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
         

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-		<version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
         

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -86,16 +86,6 @@
 				<extensions>true</extensions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.rat</groupId>
-				<artifactId>apache-rat-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>src/main/resources/project.version</exclude>
-						<exclude>release.properties</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<configuration>

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
         

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.allenai.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI3-SNAPSHOT</version>
+    <version>2.0.0-AI2</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-    <version>2.0.0-AI2</version>
+    <version>2.0.0-AI3-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.allenai.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-		<version>2.0.0-RC2</version>
+    <version>2.0.0-AI2-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
These changes together allow us to run `mvn release:prepare` followed by `mvn release:perform` to release to allenai's bintray. It adds all the infrastructure needed to do this, and removes the apache-specific stuff that gets in the way.

The version numbering is now `{apache-version}-AI{N}`, where N is an integer. Thus, the `-AI2` suffix does not mean AI2, it means this is the second version of the allenai releases from this repo. I started with 2 because it's forked from apache's `-RC2` release. The maven release plugin handles this suffix perfectly.
